### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wazo-wda-ring-fmw",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wazo-wda-ring-fmw",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@wazo/euc-plugins-sdk": "^1.1.1",
         "copy-webpack-plugin": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "webpack": "^5.109.2",
     "webpack-cli": "^6.0.1"
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Wazo Plugin WDA ring FMW",
   "name": "wazo-wda-ring-fmw",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "0.1",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "id": "wazo-ring",
   "packageName": "com.wazo.ring",
   "productType": "app",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "0.1",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "id": "wazo-ring",
   "packageName": "com.wazo.ring",
   "productType": "app",


### PR DESCRIPTION
Bump de version pour la release 1.2.0, à merger avant le tag.

La version est portée à `1.2.0` dans les trois emplacements qui doivent rester alignés :

| Fichier | Rôle |
|---|---|
| `package.json` (+ `package-lock.json`) | version du paquet |
| `src/manifest.json` | **la version lue par le WDA** |
| `public/manifest.json` | généré par le build, doit suivre |

`public/manifest.json` est régénéré par `npm run build` et non édité à la main. Depuis le retrait de `webpack-auto-inject-version-next` (#11), plus rien ne bump automatiquement — il faut donc penser au rebuild, sinon le manifest publié annonce l'ancienne version.

## Pourquoi un minor

Aucune rupture d'API ni de comportement, mais du changement visible pour l'utilisateur final, accumulé depuis v1.1.1 (juillet 2024) :

- montée du SDK Wazo `@wazo/euc-plugins-sdk` 0.0.23 → 1.1.1
- icônes SVG inline à la place de Font Awesome — ce changement existait dans `src/` mais n'avait jamais été livré, le `public/` publié étant périmé
- une dépendance CDN de moins, et intégrité vérifiée (SRI) sur celle qui reste
- les 5 sonneries sous copyright ne sont plus distribuées

## Plan de test

- [x] `npm run build` : `public/manifest.json` passe bien à 1.2.0
- [x] Les trois fichiers de version sont alignés
- [ ] Tag `v1.2.0` et release GitHub : après merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no application logic or runtime behavior modified.
> 
> **Overview**
> **Release prep:** bumps the plugin from **1.1.1** to **1.2.0** everywhere the WDA and npm tooling read the version.
> 
> `package.json` and `package-lock.json` carry the package version; `src/manifest.json` is the source manifest the WDA uses; `public/manifest.json` is updated so the built artifact matches (it should stay in sync via `npm run build` after merges, since automatic version injection was removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334290132614a04806997f7060a6bc13e9fb4c54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->